### PR TITLE
Update version of ssh2 dependency to squash build warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.9.3
+- Update ssh2 version
+
 ## 0.9.2
 - Internal improvement: fix escaping when using bash.
 

--- a/spurs-util/Cargo.toml
+++ b/spurs-util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spurs-util"
-version = "0.3.1" # remember to update html_root_url
+version = "0.3.2" # remember to update html_root_url
 authors = ["mark-i-m"]
 edition = "2018"
 license = "MIT/Apache-2.0"
@@ -14,9 +14,9 @@ Utilities for setting up and running experiments remotely.
 categories = ["science"]
 
 [dependencies]
-spurs = "0.9.2"
+spurs = "0.9.3"
 log = "0.4.6"
 env_logger = "0.6.0"
 
 [dev-dependencies]
-spurs = { version = "0.9.2", features = ["test"] }
+spurs = { version = "0.9.3", features = ["test"] }

--- a/spurs-util/src/lib.rs
+++ b/spurs-util/src/lib.rs
@@ -12,7 +12,7 @@
 //!
 //! The `centos` and `ubuntu` submodules contain routines specifically useful for those platforms.
 
-#![doc(html_root_url = "https://docs.rs/spurs-util/0.3.1")]
+#![doc(html_root_url = "https://docs.rs/spurs-util/0.3.2")]
 
 pub mod centos;
 pub mod ubuntu;

--- a/spurs/Cargo.toml
+++ b/spurs/Cargo.toml
@@ -18,7 +18,7 @@ default = []
 test = []
 
 [dependencies]
-ssh2 = "0.3.3"
+ssh2 = "0.9.5"
 dirs = "1.0.4"
 console = "0.7.2"
 log = "0.4.6"

--- a/spurs/Cargo.toml
+++ b/spurs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spurs"
-version = "0.9.2" # remember to update html_root_url
+version = "0.9.3" # remember to update html_root_url
 authors = ["mark-i-m"]
 edition = "2018"
 license = "MIT/Apache-2.0"

--- a/spurs/src/lib.rs
+++ b/spurs/src/lib.rs
@@ -303,7 +303,8 @@ impl SshShell {
 
         // Start an SSH session
         let mut sess = Session::new().unwrap();
-        sess.handshake(&tcp)?;
+        sess.set_tcp_stream(tcp.try_clone()?);
+        sess.handshake()?;
         trace!("SSH session handshook.");
         sess.userauth_pubkey_file(username, None, key.as_ref(), None)?;
         if !sess.authenticated() {
@@ -353,7 +354,8 @@ impl SshShell {
 
         // Start an SSH session
         let mut sess = Session::new().unwrap();
-        sess.handshake(&tcp)?;
+        sess.set_tcp_stream(tcp.try_clone()?);
+        sess.handshake()?;
         trace!("SSH session handshook.");
         sess.userauth_pubkey_file(&shell.username, None, shell.key.as_ref(), None)?;
         if !sess.authenticated() {
@@ -595,7 +597,8 @@ impl Execute for SshShell {
         // Start an SSH session
         debug!("Attempt to create new SSH session...");
         let mut sess = Session::new().unwrap();
-        sess.handshake(&self.tcp)?;
+        sess.set_tcp_stream(self.tcp.try_clone()?);
+        sess.handshake()?;
         trace!("Handshook!");
         sess.userauth_pubkey_file(&self.username, None, self.key.as_ref(), None)?;
         if !sess.authenticated() {

--- a/spurs/src/lib.rs
+++ b/spurs/src/lib.rs
@@ -10,7 +10,7 @@
 //! me to build my cluster setup/experiments scripts/framework in rust, with much greater
 //! productivity and refactorability.
 
-#![doc(html_root_url = "https://docs.rs/spurs/0.9.2")]
+#![doc(html_root_url = "https://docs.rs/spurs/0.9.3")]
 
 use std::{
     io::Read,


### PR DESCRIPTION
Hi Mark,

When building a project depending on spurs on rustc version 1.91.1, I get the following build error.

`warning: the following packages contain code that will be rejected by a future version of Rust: bitflags v0.7.0)`

The bitflags crate is a dependency of the ssh2 crate that spurs depends on. This PR upgrades ssh2 from version 0.3.3 to 0.9.5, which depends on an upgraded version of the bitflags crate, getting rid of this issue.

No functional change is intended.

Thanks,
Bijan